### PR TITLE
📜 docs: Changed README Badges back to Markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,31 +1,3 @@
-<a href="https://github.com/TJC-Tools/TJC.Collection.MVVM/tags">
-  <img alt="GitHub Tag" src="https://img.shields.io/github/v/tag/TJC-Tools/TJC.Collection.MVVM?style=for-the-badge&logo=tag&logoColor=white&labelColor=24292f&color=blue" />
-</a>
+![GitHub Tag](https://img.shields.io/github/v/tag/TJC-Tools/TJC.Collection.MVVM) [![GitHub Release](https://img.shields.io/github/v/release/TJC-Tools/TJC.Collection.MVVM)](https://github.com/TJC-Tools/TJC.Collection.MVVM/releases/latest) [![NuGet Version](https://img.shields.io/nuget/v/TJC.Collection.MVVM)](https://www.nuget.org/packages/TJC.Collection.MVVM)
 
-<a href="https://github.com/TJC-Tools/TJC.Collection.MVVM/releases/latest">
-  <img alt="GitHub Release" src="https://img.shields.io/github/v/release/TJC-Tools/TJC.Collection.MVVM?style=for-the-badge&logo=starship&logoColor=D9E0EE&labelColor=302D41&&color=green&include_prerelease&sort=semver" />
-</a>
-
-<a href="https://www.nuget.org/packages/TJC.Collection.MVVM">
-  <img alt="NuGet Version" src="https://img.shields.io/nuget/v/TJC.Collection.MVVM?style=for-the-badge&logo=nuget&logoColor=white&labelColor=004880&color=blue" />
-</a>
-
-<br/>
-
-<a href="https://www.nuget.org/packages/TJC.Collection.MVVM">
-  <img alt="NuGet Downloads" src="https://img.shields.io/nuget/dt/TJC.Collection.MVVM?style=for-the-badge&logo=nuget&logoColor=white&labelColor=004880&color=yellow" />
-</a>
-
-<a href="https://github.com/TJC-Tools/TJC.Collection.MVVM">
-  <img alt="Repository Size" src="https://img.shields.io/github/repo-size/TJC-Tools/TJC.Collection.MVVM?style=for-the-badge&logo=files&logoColor=white&labelColor=24292f&color=orange" />
-</a>
-
-<br/>
-
-<a href="https://github.com/TJC-Tools/TJC.Collection.MVVM">
-  <img alt="Last commit" src="https://img.shields.io/github/last-commit/TJC-Tools/TJC.Collection.MVVM?style=for-the-badge&logo=git&logoColor=D9E0EE&labelColor=302D41&color=mediumpurple"/>
-</a>
-
-<a href="LICENSE">
-  <img alt="License" src="https://img.shields.io/github/license/TJC-Tools/TJC.Collection.MVVM.svg?style=for-the-badge&logo=balance-scale&logoColor=white&labelColor=333333&color=blueviolet" />
-</a>
+[![NuGet Downloads](https://img.shields.io/nuget/dt/TJC.Collection.MVVM)](https://www.nuget.org/packages/TJC.Collection.MVVM) ![Size](https://img.shields.io/github/repo-size/TJC-Tools/TJC.Collection.MVVM) [![License](https://img.shields.io/github/license/TJC-Tools/TJC.Collection.MVVM.svg)](LICENSE)


### PR DESCRIPTION
Since HTML Badges don't render on nuget